### PR TITLE
Fix misleading statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ is in the cart is by changing the className on the `<li>` element:
 
 If the item _is not_ in the cart, the `<button>` element's text should read "Add
 to Cart", and if the item _is_ in the cart, the `<button>` element's text should
-read "Remove From Cart". You could add more state to the `Item`
-component to solve this deliverable, but see if you can find a way not to.
+read "Remove From Cart". You could add more state to the `Item` component to 
+solve this deliverable, but see if you can complete this deliverable without 
+doing so.
 
 ### Filter
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ is in the cart is by changing the className on the `<li>` element:
 
 If the item _is not_ in the cart, the `<button>` element's text should read "Add
 to Cart", and if the item _is_ in the cart, the `<button>` element's text should
-read "Remove From Cart". Naturally, you'll also need to add state to the `Item`
-component to solve this deliverable!
+read "Remove From Cart". You could add more state to the `Item`
+component to solve this deliverable, but see if you can find a way not to.
 
 ### Filter
 


### PR DESCRIPTION
Previous lessons taught that a best practice is not to create more state unnecessarily. This lab says "Naturally, you'll also need to add state to the Item component to solve this deliverable!" This is false, and you can complete the lab using only the 1 state from the previous deliverable (see code below). The lesson will be more accurate and more helpful by fixing the statement in the PR.

```
function Item({ name, category }) {
const [ inCart, setInCart ] = useState('');

function addToCart() {
  inCart === '' ? setInCart(inCart => 'in-cart') : setInCart(inCart => '');
}

function isInCart() {
  return inCart === '' ? 'Add to Cart' : 'Remove From Cart';
}

  return (
    <li className={inCart} onClick={addToCart}>
      <span>{name}</span>
      <span className="category">{category}</span>
      <button className="add">{isInCart()}</button>
    </li>
  );
}```