### PR TITLE
fixes test query selectors to search for App light and App dark class

### DIFF
--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -4,27 +4,27 @@ import App from "../components/App";
 
 test("displays in 'light' mode when initialized", () => {
   const { container } = render(<App />);
-  expect(container.querySelector(".light")).toBeInTheDocument();
+  expect(container.querySelector(".App.light")).toBeInTheDocument();
 });
 
 test("changes to 'dark' mode when the button is clicked", () => {
   const { container } = render(<App />);
-  expect(container.querySelector(".light")).toBeInTheDocument();
+  expect(container.querySelector(".App.light")).toBeInTheDocument();
 
   fireEvent.click(screen.getByText(/ Mode/));
 
-  expect(container.querySelector(".dark")).toBeInTheDocument();
+  expect(container.querySelector(".App.dark")).toBeInTheDocument();
 });
 
 test("changes back to 'light' mode when the button is clicked twice", () => {
   const { container } = render(<App />);
-  expect(container.querySelector(".light")).toBeInTheDocument();
+  expect(container.querySelector(".App.light")).toBeInTheDocument();
 
   fireEvent.click(screen.getByText(/ Mode/));
 
-  expect(container.querySelector(".dark")).toBeInTheDocument();
+  expect(container.querySelector(".App.dark")).toBeInTheDocument();
 
   fireEvent.click(screen.getByText(/ Mode/));
 
-  expect(container.querySelector(".light")).toBeInTheDocument();
+  expect(container.querySelector(".App.light")).toBeInTheDocument();
 });


### PR DESCRIPTION
The tests shouldn't be looking for light and dark if the div's class is supposed to be App dark and App light based on the css file. If they are supposed to add a class to the button per se, we should provide directions. 